### PR TITLE
Support for GY-88 added

### DIFF
--- a/config.h
+++ b/config.h
@@ -129,6 +129,7 @@
       //#define GY_80           // Chinese 10 DOF with  L3G4200D ADXL345 HMC5883L BMP085, LLC
       //#define GY_85           // Chinese 9 DOF with  ITG3205 ADXL345 HMC5883L LLC
       //#define GY_86           // Chinese 10 DOF with  MPU6050 HMC5883L MS5611, LLC
+      //#define GY_88           // Chinese 10 DOF with  MPU6050 HMC5883L BMP085, LLC
       //#define GY_521          // Chinese 6  DOF with  MPU6050, LLC
       //#define INNOVWORKS_10DOF // with ITG3200, BMA180, HMC5883, BMP085 available here http://www.diymulticopter.com
       //#define INNOVWORKS_6DOF // with ITG3200, BMA180 available here http://www.diymulticopter.com

--- a/def.h
+++ b/def.h
@@ -1265,6 +1265,17 @@
   #undef INTERNAL_I2C_PULLUPS
 #endif
 
+#if defined(GY_88)
+	#define MPU6050
+	#define HMC5883
+	#define BMP085
+	#define ACC_ORIENTATION(X, Y, Z)  {imu.accADC[ROLL]  = -X; imu.accADC[PITCH]  = -Y; imu.accADC[YAW]  =  Z;}
+	#define GYRO_ORIENTATION(X, Y, Z) {imu.gyroADC[ROLL] =  Y; imu.gyroADC[PITCH] = -X; imu.gyroADC[YAW] = -Z;}
+	#define MAG_ORIENTATION(X, Y, Z)  {imu.magADC[ROLL]  =  X; imu.magADC[PITCH]  =  Y; imu.magADC[YAW]  = -Z;}
+	#define MPU6050_I2C_AUX_MASTER // MAG connected to the AUX I2C bus of MPU6050
+	//#undef INTERNAL_I2C_PULLUPS
+#endif
+
 #if defined(GY_521)
   #define MPU6050
   #define ACC_ORIENTATION(X, Y, Z)  {imu.accADC[ROLL]  = -X; imu.accADC[PITCH]  = -Y; imu.accADC[YAW]  =  Z;}


### PR DESCRIPTION
This Chinese IMU board becomes very popular and contains already supported chips.
Amazon: http://www.amazon.com/Happy-Store-MPU-6050-HMC5883L-Control/dp/B00G8T6ZVK
AliExpress: http://www.aliexpress.com/item/GY-88-10DOF-IMU-MPU6050-HMC5883L-BMP085-for-Arduino-Accel-Gyro-Baro-Mag-UNO-Mega-DUE/1377907454.html

Tested with Nano v.3, SDA/SCL connected directly without pullup resistors.
