### PR TITLE
Fix for heading > 180 degrees or < -180 degrees with magnetic declination

### DIFF
--- a/IMU.cpp
+++ b/IMU.cpp
@@ -261,6 +261,10 @@ void getEstimatedAttitude(){
     att.heading += conf.mag_declination; // Set from GUI
   #endif
   att.heading /= 10;
+  if(att.heading > 180)
+    att.heading = -180 + (att.heading % 180);  // compensate for mag_declination 
+  else if(att.heading < -179)
+    att.heading = 180 + (att.heading % 180);
 
   #if defined(THROTTLE_ANGLE_CORRECTION)
     cosZ = mul(EstG.V16.Z , 100) / ACC_1G ;                                                   // cos(angleZ) * 100 

--- a/IMU.cpp
+++ b/IMU.cpp
@@ -265,6 +265,11 @@ void getEstimatedAttitude(){
   #if defined(THROTTLE_ANGLE_CORRECTION)
     cosZ = mul(EstG.V16.Z , 100) / ACC_1G ;                                                   // cos(angleZ) * 100 
     throttleAngleCorrection = THROTTLE_ANGLE_CORRECTION * constrain(100 - cosZ, 0, 100) >>3;  // 16 bit ok: 200*150 = 30000  
+  if(att.heading > 180)
+    att.heading = -180 + (att.heading % 180);  // compensate for mag_declination 
+  else if(att.heading < -179)
+    att.heading = 180 + (att.heading % 180);
+
   #endif
 
   // projection of ACC vector to global Z, with 1G subtructed

--- a/IMU.cpp
+++ b/IMU.cpp
@@ -265,11 +265,6 @@ void getEstimatedAttitude(){
   #if defined(THROTTLE_ANGLE_CORRECTION)
     cosZ = mul(EstG.V16.Z , 100) / ACC_1G ;                                                   // cos(angleZ) * 100 
     throttleAngleCorrection = THROTTLE_ANGLE_CORRECTION * constrain(100 - cosZ, 0, 100) >>3;  // 16 bit ok: 200*150 = 30000  
-  if(att.heading > 180)
-    att.heading = -180 + (att.heading % 180);  // compensate for mag_declination 
-  else if(att.heading < -179)
-    att.heading = 180 + (att.heading % 180);
-
   #endif
 
   // projection of ACC vector to global Z, with 1G subtructed


### PR DESCRIPTION
If a magnetic declination is specified, this value is simply added to the heading computed by the flight controller. As a result if the heading returned by the magnetometer is 170 degrees and you have specified a declination of 20 degrees the heading reported by Multiwii is 190 degrees instead of -170.
