### PR TITLE
Add Support for BMP280 Barometer Sensor

### DIFF
--- a/config.h
+++ b/config.h
@@ -184,6 +184,7 @@
 
       /* I2C barometer */
       //#define BMP085
+      //#define BMP280
       //#define MS561101BA
 
       /* I2C magnetometer */

--- a/def.h
+++ b/def.h
@@ -1686,7 +1686,7 @@
   #define GYRO 0
 #endif
 
-#if defined(BMP085) || defined(MS561101BA)
+#if defined(BMP085) || defined(BMP280) || defined(MS561101BA)
   #define BARO 1
 #else
   #define BARO 0


### PR DESCRIPTION
Added Support for BMP280 I2C Barometer. 

This sensor is cheaper and provides a higher resolution than BMP085 Barometer.

Resolves #30 